### PR TITLE
Fix code scanning alert no. 28: Unnecessary use of `cat` process

### DIFF
--- a/platform/Platform.js
+++ b/platform/Platform.js
@@ -68,7 +68,7 @@ class Platform {
   getSignatureMac() {
     if (!this.signatureMac) {
       try {
-        const mac = cp.execSync("cat /sys/class/net/eth0/address", {encoding: 'utf8'});
+        const mac = fs.readFileSync("/sys/class/net/eth0/address", {encoding: 'utf8'});
         this.signatureMac = mac && mac.trim().toUpperCase();
       } catch (err) {}
     }

--- a/testLegacy/test_dnsmasq.js
+++ b/testLegacy/test_dnsmasq.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+let fs = require('fs');
 let chai = require('chai');
 let expect = chai.expect;
 
@@ -21,7 +22,7 @@ dnsmasq.cleanUpPolicyFilter()
 
         dnsmasq.addPolicyFilterEntries(["test2.com", "test3.com"])
           .then(() => {
-            console.log(require("child_process").execSync("cat ~/.firewalla/config/dns/policy_filter.conf").toString("utf8"));
+            console.log(fs.readFileSync("~/.firewalla/config/dns/policy_filter.conf").toString("utf8"));
             
             dnsmasq.start(false, (err) => {
               expect(err).to.equal(undefined);


### PR DESCRIPTION
Fixes https://github.com/parkerbxyz/firewalla/security/code-scanning/28 and https://github.com/parkerbxyz/firewalla/security/code-scanning/29.

Replaces the use of `cp.execSync("cat /sys/class/net/eth0/address", {encoding: 'utf8'})` with `fs.readFileSync("/sys/class/net/eth0/address", {encoding: 'utf8'})`. This change will make the code more secure, portable, and efficient without altering its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
